### PR TITLE
Fix #42 "dependency is an expression" warn when using Webpack.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export class Localize {
     // then merger the Language pack
     // just in case the resolveLanguage bundle missing the translation and fallback with default language
     if (resolvedLanguage !== defaultResvoleLanguage) {
-      defaultLanguageBundle = require(path.join(file + defaultResvoleLanguage));
+      defaultLanguageBundle = JSON.parse(fs.readFileSync(path.join(file + defaultResvoleLanguage)));
     }
 
     const languageFilePath = path.join(file + resolvedLanguage);
@@ -81,7 +81,7 @@ export class Localize {
     const isExistResolvedLanguage = fs.existsSync(languageFilePath);
 
     const ResolvedLanguageBundle = isExistResolvedLanguage
-      ? require(languageFilePath)
+      ? JSON.parse(fs.readFileSync(languageFilePath))
       : {};
 
     // merger with default language bundle


### PR DESCRIPTION
When using webpack, we will get these warnings:
```
WARNING in ./node_modules/vscode-nls-i18n/dist/index.js 70:36-85
Critical dependency: the request of a dependency is an expression
 @ ./src/extension.ts 9:26-52

WARNING in ./node_modules/vscode-nls-i18n/dist/index.js 75:14-39
Critical dependency: the request of a dependency is an expression
 @ ./src/extension.ts 9:26-52
```
And debug vscode extension will not successd. See issue #42 