### PR TITLE
change package 'vscode' to @type/vscode.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-nls-i18n",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "i18n support for vscode extension",
   "main": "./dist/index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/axetroy/vscode-nls-i18n#readme",
   "devDependencies": {
     "@types/node": "11.15.33",
-    "typescript": "4.0.5",
-    "vscode": "1.1.37"
+    "@types/vscode": "^1.44.0",
+    "typescript": "4.0.5"
   }
 }


### PR DESCRIPTION
As you can see here : https://www.npmjs.com/package/vscode, package 'vscode' is depreciated and was split into '@types/vscode' and 'vscode-test'.
I changed vscode to @types/vscode because when we develop vscode extensions nowadays, we do not add 'vscode' package anymore and end up having an error thrown at runtime when using 'vscode-nls-i18n' package:
![image](https://user-images.githubusercontent.com/1506373/128629651-b532b976-4028-43c6-a751-62c2c8b7cd4f.png)

